### PR TITLE
add slashes to catch expression

### DIFF
--- a/autoload/fold_cycle.vim
+++ b/autoload/fold_cycle.vim
@@ -153,7 +153,7 @@ function! s:do_find_branch(line, type) abort "{{{3
             normal! zo
         endif
 
-    catch ^Vim\%((\a\+)\)\=:E490
+    catch /^Vim\%((\a\+)\)\=:E490/
         let value = 0 "TODO use symbolic constant
 
     endtry


### PR DESCRIPTION
Without exterior slashes vim 8.2.0728 throws the following messages:
```
 Error detected while processing function fold_cycle#open[1]..<SNR>183_init[19]..<SNR>183_find_branch_start[1]..<SNR>183_do_find_branch:
line   27:
E654: missing delimiter after search pattern: Vim\%((\a\+)\)\=:E490
Error detected while processing function fold_cycle#open:
line    1:
E171: Missing :endif
```
`:help catch` gives the following example:
```vim
:catch /^Vim\%((\a\+)\)\=:E123:/ " catch error E123
```